### PR TITLE
do not publish if which fails

### DIFF
--- a/git-achievements
+++ b/git-achievements
@@ -369,6 +369,9 @@ function clean_logged_achievements() {
 
 function publish_achievements
 {
+    if [ $(which git-achievements) != 0 ]; then
+      return
+    fi
     git_achievements="$(which git-achievements)"
     git_achievements_dir="$(dirname "${git_achievements}")"
     if [ -L "${git_achievements}" ]; then


### PR DESCRIPTION
cd doesn't work with unexpanded ~ in path, while bash does, which can
lead to achievements being unlocked with git-achievements not in path
which will lead to commits being made against the current git
repository, which is really ugly
